### PR TITLE
chore: no need for package script semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "test:watch": "jest --watchAll",
     "build": "tsc",
     "watch": "tsc -w",
-    "start": "npm link && nodemon",
-    "semantic-release": "semantic-release"
+    "start": "npm link && nodemon"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey, so I noticed a `semantic-release` script in `package.json` that just aliases the executable from the dependency. Just wondering if there's an awesome reason this is good anyway (perhaps to document?), otherwise, if you weren't aware:
> yarn run [script] [<args>]
>
> [script] can also be any locally installed executable that is inside node_modules/.bin/

https://classic.yarnpkg.com/en/docs/cli/run/#toc-yarn-run-script